### PR TITLE
Fix warning about creds input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,8 @@ inputs:
   version:
     description: 'azcopy version to download. (currently can set `v10` only'
     default: 'v10'
+  creds:
+    description: 'Paste output of `az ad sp create-for-rbac` as value of secret variable: AZURE_CREDENTIALS'
 branding:
   icon: 'triangle'  
   color: 'blue'


### PR DESCRIPTION
Add creds input to `action.yml` to prevent the 
```
Unexpected input(s) 'creds', valid inputs are ['version']
```
warning.