### PR TITLE
Fix typo and Update to Node 16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         operating-system: [ubuntu-20.04, ubuntu-18.04, macos-11.0, macos-10.15, windows-2019]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: |
         azcopy --version | grep 'azcopy'
         which azcopy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,16 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ubuntu-20.04, ubuntu-18.04, macos-11.0, macos-10.15, windows-2019]
+        operating-system: [
+          ubuntu-22.04,
+          ubuntu-20.04,
+          ubuntu-18.04,
+          macos-12,
+          macos-11.0,
+          macos-10.15,
+          windows-2022,
+          windows-2019,
+        ]
     steps:
     - uses: actions/checkout@v2
     - run: |

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ async function run(): Promise<void> {
   }
   const creds = core.getInput('creds', {required: false})
   if (creds === '') {
-    core.debug('creds is not difined.')
+    core.debug('creds is not defined.')
     return
   }
   const secrets = new SecretParser(creds, FormatType.JSON)


### PR DESCRIPTION
- Fix typo
- Follow [this post](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
- Support new operating system