### PR TITLE
azcopy login is deprecated

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           windows-2019,
         ]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: |
         node --version
         npm --version
@@ -39,7 +39,7 @@ jobs:
           windows-2019
         ]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: |
         azcopy --version | grep 'azcopy'
         which azcopy

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ This credentials feature is for sharing same credentials with [azure-login](http
 How to create Azure credentials?  
 -> Please check [azure-login page](https://github.com/marketplace/actions/azure-login#configure-azure-credentials).
 
+install-azcopy-action only support authorize with a service principal using a lient secret.  
+https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-authorize-azure-active-directory#authorize-a-service-principal-by-using-a-client-secret
+
 # Develop
 
 install-azcopy-action is tested below.

--- a/dist/index.js
+++ b/dist/index.js
@@ -55,7 +55,7 @@ function installAzCopy(version) {
             downloadPath = yield tc.downloadTool(downloadUrl);
         }
         catch (error) {
-            if (typeof error === "string") {
+            if (typeof error === 'string') {
                 core.debug(error);
             }
             else if (error instanceof Error) {
@@ -142,17 +142,15 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const core = __importStar(__nccwpck_require__(2186));
 const installer = __importStar(__nccwpck_require__(1480));
-const exec = __importStar(__nccwpck_require__(1514));
 const actions_secret_parser_1 = __nccwpck_require__(5074);
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
-        let azcopyPath = '';
         try {
             const version = core.getInput('version', { required: true });
-            azcopyPath = yield installer.installAzCopy(version);
+            yield installer.installAzCopy(version);
         }
         catch (error) {
-            if (typeof error === "string") {
+            if (typeof error === 'string') {
                 core.setFailed(error);
             }
             else if (error instanceof Error) {
@@ -172,19 +170,10 @@ function run() {
         if (!servicePrincipalId || !servicePrincipalKey || !tenantId) {
             throw new Error('Not all values are present in the creds object. Ensure clientId, clientSecret, tenantId and subscriptionId are supplied.');
         }
+        core.exportVariable('AZCOPY_AUTO_LOGIN_TYPE', 'SPN');
+        core.exportVariable('AZCOPY_SPA_APPLICATION_ID', servicePrincipalId);
         core.exportVariable('AZCOPY_SPA_CLIENT_SECRET', servicePrincipalKey);
-        try {
-            yield exec.exec(`"${azcopyPath}" login --service-principal --application-id ${servicePrincipalId} --tenant-id ${tenantId}`, [], {});
-        }
-        catch (error) {
-            core.error('Login failed. Please check the credentials.');
-            if (typeof error === "string") {
-                core.setFailed(error);
-            }
-            else if (error instanceof Error) {
-                core.setFailed(error.message);
-            }
-        }
+        core.exportVariable('AZCOPY_TENANT_ID', tenantId);
     });
 }
 run();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,12 @@
 import * as core from '@actions/core'
 import * as installer from './installer'
-import * as exec from '@actions/exec'
 
 import {FormatType, SecretParser} from 'actions-secret-parser'
 
 async function run(): Promise<void> {
-  let azcopyPath = ''
   try {
     const version = core.getInput('version', {required: true})
-    azcopyPath = await installer.installAzCopy(version)
+    await installer.installAzCopy(version)
   } catch (error) {
     if (typeof error === 'string') {
       core.setFailed(error)
@@ -31,21 +29,10 @@ async function run(): Promise<void> {
       'Not all values are present in the creds object. Ensure clientId, clientSecret, tenantId and subscriptionId are supplied.'
     )
   }
+  core.exportVariable('AZCOPY_AUTO_LOGIN_TYPE', 'SPN')
+  core.exportVariable('AZCOPY_SPA_APPLICATION_ID', servicePrincipalId)
   core.exportVariable('AZCOPY_SPA_CLIENT_SECRET', servicePrincipalKey)
-  try {
-    await exec.exec(
-      `"${azcopyPath}" login --service-principal --application-id ${servicePrincipalId} --tenant-id ${tenantId}`,
-      [],
-      {}
-    )
-  } catch (error) {
-    core.error('Login failed. Please check the credentials.')
-    if (typeof error === 'string') {
-      core.setFailed(error)
-    } else if (error instanceof Error) {
-      core.setFailed(error.message)
-    }
-  }
+  core.exportVariable('AZCOPY_TENANT_ID', tenantId)
 }
 
 run()


### PR DESCRIPTION
Use in-memory variables authentication instead of azcopy login command.
Because it will be deprecated.
https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-authorize-azure-active-directory#authorize-by-using-the-azcopy-login-command